### PR TITLE
Fix indexing error for proportional palettes

### DIFF
--- a/src/bin/kmeans_colors/args.rs
+++ b/src/bin/kmeans_colors/args.rs
@@ -133,6 +133,11 @@ pub struct Opt {
     /// Maps the image to the user supplied colors.
     #[structopt(subcommand, name = "command")]
     pub cmd: Option<Command>,
+
+    /// Ignore alpha channel values for calculation of k-means, does not output
+    /// an image but will output palettes.
+    #[structopt(long, hidden = true)]
+    pub transparent: bool,
 }
 
 #[derive(StructOpt, Debug)]

--- a/src/bin/kmeans_colors/utils.rs
+++ b/src/bin/kmeans_colors/utils.rs
@@ -167,11 +167,16 @@ pub fn save_palette_lab(
                 if let Some((last, elements)) = res.split_last() {
                     for r in elements.iter() {
                         let pix: [u8; 3] = Srgb::from(r.0).into_format().into_raw();
-                        let boundary = (curr_pos as f32 + (r.1 * w as f32)).round() as u32;
+                        // Clamp boundary to image width
+                        let boundary = ((curr_pos as f32 + (r.1 * w as f32)).round() as u32).min(w);
                         for y in 0..height {
                             for x in curr_pos..boundary {
                                 imgbuf.put_pixel(x, y, image::Rgb(pix));
                             }
+                        }
+                        // If boundary has been clamped, return early
+                        if boundary == w {
+                            return Ok(save_image(&imgbuf.to_vec(), w, height, title)?);
                         }
                         curr_pos = boundary;
                     }
@@ -203,11 +208,14 @@ pub fn save_palette_lab(
                 if let Some((last, elements)) = res.split_last() {
                     for r in elements.iter() {
                         let pix: [u8; 3] = Srgb::from(r.0).into_format().into_raw();
-                        let boundary = (curr_pos as f32 + (r.1 * w as f32)).round() as u32;
+                        let boundary = ((curr_pos as f32 + (r.1 * w as f32)).round() as u32).min(w);
                         for y in 0..height {
                             for x in curr_pos..boundary {
                                 imgbuf.put_pixel(x, y, image::Rgb(pix));
                             }
+                        }
+                        if boundary == w {
+                            return Ok(save_image(&imgbuf.to_vec(), w, height, title)?);
                         }
                         curr_pos = boundary;
                     }
@@ -265,11 +273,14 @@ pub fn save_palette_rgb(
                 if let Some((last, elements)) = res.split_last() {
                     for r in elements.iter() {
                         let pix: [u8; 3] = (r.0).into_format().into_raw();
-                        let boundary = (curr_pos as f32 + (r.1 * w as f32)).round() as u32;
+                        let boundary = ((curr_pos as f32 + (r.1 * w as f32)).round() as u32).min(w);
                         for y in 0..height {
                             for x in curr_pos..boundary {
                                 imgbuf.put_pixel(x, y, image::Rgb(pix));
                             }
+                        }
+                        if boundary == w {
+                            return Ok(save_image(&imgbuf.to_vec(), w, height, title)?);
                         }
                         curr_pos = boundary;
                     }
@@ -301,11 +312,14 @@ pub fn save_palette_rgb(
                 if let Some((last, elements)) = res.split_last() {
                     for r in elements.iter() {
                         let pix: [u8; 3] = (r.0).into_format().into_raw();
-                        let boundary = (curr_pos as f32 + (r.1 * w as f32)).round() as u32;
+                        let boundary = ((curr_pos as f32 + (r.1 * w as f32)).round() as u32).min(w);
                         for y in 0..height {
                             for x in curr_pos..boundary {
                                 imgbuf.put_pixel(x, y, image::Rgb(pix));
                             }
+                        }
+                        if boundary == w {
+                            return Ok(save_image(&imgbuf.to_vec(), w, height, title)?);
                         }
                         curr_pos = boundary;
                     }


### PR DESCRIPTION
Palette width wasn't clamped so there was a possibility of off-by-one
when working with very small percentages in proportional palettes. This
became apparent when they were sorted and for large sizes.

Add flag for working with transparent images. First steps of working
with handling k-means for transparent pngs. The flag is hidden and
only good for finding the colors or producing a palette. It's a special
case that will require more logic for outputting a full image. This
will be completed with hopefully a followup change to generics.