### PR TITLE
Implement Hamerly's algorithm for Lab and Srgb

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,19 @@
 
 Calculate the `k` average colors in an image using k-means clustering.
 
+k-means can find the dominant colors or color palette of an image. Other
+applications in this crate are binarization, line extraction, and "color style"
+transfer. The crate wraps around a generic [k-means implementation][lib] that 
+supports Lloyd's and Hamerly's algorithms for arbitrary data types.
+
+[lib]: https://docs.rs/kmeans_colors/
+
+## 1) Basic usage
+![Animation of flowers](gfx/pink.gif)
+```
+kmeans_colors -i gfx/pink.jpg -k 2 -r 3 -o pink2
+```
+
 k-means clustering works by starting with an initial random guess of the `k`
 number of colors in the image called `centroids`. For each step, every pixel in
 the image is traversed to find what centroid is closest to it in color. Then,
@@ -12,26 +25,12 @@ the centroids calculate the average of all the colors close to them and move to
 that color. This process repeats until the centroids stop moving or the maximum
 step count is reached.
 
-The k-means can be used to find the dominant colors or color palette of an
-image. Some other applications are binarization, line extraction, and "color
-style" transfer. The crate wraps around a generic [k-means implementation][lib].
-
-[lib]: https://docs.rs/kmeans_colors/
-
-## Examples
-
-### 1) Basic usage
-```
-kmeans_colors -i gfx/pink.jpg -k 2 -r 3 -o pink2
-```
-![Animation of flowers](gfx/pink.gif)
-
 The animation is a composite of k=2 to k=9 k-means with the above command.
 `-k` is the number of colors to find in the image. `-r` is the amount of runs
 to perform, `-o` specifies the output. By default, the images will save as .png
 files. The `-o` option is not required.
 
-### 2) Color palettes
+## 2) Color palettes
 
 ```
 kmeans_colors -i gfx/lanterns.jpg --no-file --palette
@@ -54,9 +53,9 @@ will rearrange the palette in order from most frequent to least frequent color.
 The `--height` and `--width` of the palette can be specified as well as output
 name with `--op`. Passing `-k 1` will produce the average color of the image.
 
-### 3) The `find` subcommand
+## 3) The `find` subcommand
 
-#### a) Binary Ferris Example
+### a) Binary Ferris Example
 
 We can use k-means to clean up this doodle and extract the line work from it.
 The paper this is on is folded and scribbled over with highlighter and 
@@ -97,7 +96,7 @@ subcommand with the `-c` option, which allows us to specify the colors black
 iteration to find the nearest colors in the image to the colors passed with
 `-c`.
 
-#### b) The `--replace` flag
+### b) The `--replace` flag
 
 With `--replace`, we run the k-means calculation on an image and replace the
 centroids with our own custom colors. The colors we input will replace the
@@ -155,7 +154,7 @@ kmeans_colors find -i gfx/ferris-find.png -c de4a18,bee0fa --replace -o gfx/ferr
 combination. They don't do anything with `find` by itself, since only one
 iteration is needed to produce the result.
 
-### 4) Print, Percentage, & Verbose
+## 4) Print, Percentage, & Verbose
 
 `kmeans_colors -i gfx/pink.jpg -k 2 -pv --pct --no-file`
 
@@ -177,7 +176,7 @@ Iterations: 2
 0.6613,0.3387
 ```
 
-### *Usage Notes:*
+## *Usage Notes:*
 k-means can get stuck in local minima which prevent it from finding the best
 result. To combat this, the amount of runs can be specified with `-r` to repeat
 the process and keep the best result. The `-m` flag can be used to specify the
@@ -204,6 +203,7 @@ the results.
 - print the average colors
 - print the percentage of each color in the image
 - transparency support
+- adaptive switching between LLoyd's and Hamerly's algorithms based on `k` count
 - supports multiple images as input to process
 - specify random seed for reproducible results
 

--- a/src/kmeans.rs
+++ b/src/kmeans.rs
@@ -31,10 +31,10 @@ pub trait Calculate: Sized {
     fn difference(c1: &Self, c2: &Self) -> f32;
 }
 
-/// Result of k-means calculation with convergence score, centroids, and indexed
+/// Struct result of k-means calculation with convergence score, centroids, and indexed
 /// buffer.
 #[derive(Clone, Debug, Default)]
-pub struct Kmeans<C: Calculate> {
+pub struct Kmeans<C: Sized> {
     /// Sum of squares distance metric for centroids compared to old centroids.
     pub score: f32,
     /// Points determined to be centroids of input buffer.
@@ -269,6 +269,423 @@ impl Calculate for Srgb {
         (c1.red - c2.red) * (c1.red - c2.red)
             + (c1.green - c2.green) * (c1.green - c2.green)
             + (c1.blue - c2.blue) * (c1.blue - c2.blue)
+    }
+}
+
+/// A trait for calculating k-means with the Hamerly algorithm.
+pub trait Hamerly: Calculate {
+    /// Find the nearest centers and compute their half-distances.
+    fn compute_half_distances(centroids: &mut HamerlyCentroids<Self>);
+
+    /// Find a point's nearest centroid, index the point with that centroid.
+    fn get_closest_centroid_hamerly(
+        buffer: &[Self],
+        centroids: &HamerlyCentroids<Self>,
+        indices: &mut [HamerlyPoint],
+    );
+
+    /// Find the new centroid locations based on the average of the points that
+    /// correspond to the centroid. If no points correspond, the centroid is
+    /// re-initialized with a random point.
+    fn recalculate_centroids_hamerly(
+        rng: &mut impl Rng,
+        buf: &[Self],
+        centroids: &mut HamerlyCentroids<Self>,
+        points: &[HamerlyPoint],
+    );
+
+    /// Update the lower and upper bounds of each point.
+    fn update_bounds(centroids: &HamerlyCentroids<Self>, points: &mut [HamerlyPoint]);
+}
+
+/// Struct used for caching data required to compute k-means with the Hamerly
+/// algorithm.
+#[derive(Clone, Debug)]
+pub struct HamerlyCentroids<C: Hamerly> {
+    /// Centroid points.
+    pub centroids: Vec<C>,
+    /// Distances the centroids have moved since the previous iteration.
+    pub deltas: Vec<f32>,
+    /// Half-distances to nearest centroid.
+    pub half_distances: Vec<f32>,
+}
+
+impl<C: Hamerly> HamerlyCentroids<C> {
+    pub fn new(capacity: usize) -> Self {
+        HamerlyCentroids {
+            centroids: Vec::with_capacity(capacity),
+            deltas: (0..capacity).map(|_| 0.0).collect(),
+            half_distances: (0..capacity).map(|_| 0.0).collect(),
+        }
+    }
+}
+
+/// Struct that holds the necessary caching information for points in the
+/// Hamerly algorithm implementation.
+#[derive(Copy, Clone, Debug)]
+pub struct HamerlyPoint {
+    /// Index of this point's centroid.
+    pub index: u8,
+    /// Closest centroid's distance to this point.
+    pub upper_bound: f32,
+    /// Minimum distance any centroid that's not the closest can be to this
+    /// point.
+    pub lower_bound: f32,
+}
+
+impl HamerlyPoint {
+    pub fn new() -> Self {
+        HamerlyPoint {
+            index: 0,
+            upper_bound: f32::MAX,
+            lower_bound: 0.0,
+        }
+    }
+}
+
+/// Find the k-means centroids of a buffer using the Hamerly algorithm. Takes
+/// the same arguments as [`get_kmeans`](fn.get_kmeans.html) and produces the
+/// same results.
+///
+/// Hamerly uses the triangle inequality and caches one lower and upper bound
+/// for each point, which allows it to skip the inner loop of distance
+/// calculation for each point more often. Asymptotically, this algorithm
+/// performs better than the default algorithm for lower dimensional k-means
+/// taking advantage of the fact than some centroids converge very quickly.
+/// However, this method incurs additional overhead that makes it perform about
+/// the same or slightly worse at low center counts. Benchmark the functions to
+/// see which performs better for your use case.
+///
+/// Below about `k=6`, the default LLoyd's algorithm seems to perform better for
+/// three dimensional points like colors but it depends on the data. If there
+/// are many similar points, the algorithm may end up with the extra overhead
+/// and having to compute the inner loop many times as the centers fluctuate.
+/// Hamerly's algorithm excels when there is clear segmentation of clusters.
+/// Those clusters tend to converge early and all the points that belong
+/// to them can skip their distance calculations.
+///
+/// ## Referenece
+///
+/// Hamerly, G., & Drake, J. (2017). Chapter 2 Accelerating Lloyd's Algorithm
+/// for k-Means Clustering.
+///
+/// Hamerly, G. (2010). Making k-means even faster. In: SIAM international
+/// conference on data mining.
+pub fn get_kmeans_hamerly<C: Hamerly + Clone>(
+    k: usize,
+    max_iter: usize,
+    converge: f32,
+    verbose: bool,
+    buf: &[C],
+    seed: u64,
+) -> Kmeans<C> {
+    // Initialize the random centroids
+    let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
+    let mut centers: HamerlyCentroids<C> = HamerlyCentroids::new(k);
+    (0..k).for_each(|_| centers.centroids.push(Calculate::create_random(&mut rng)));
+
+    // Initialize points buffer and convergence variables
+    let mut iterations = 0;
+    let mut score;
+    let mut old_centers = centers.centroids.clone();
+    let mut points: Vec<HamerlyPoint> = (0..buf.len()).map(|_| HamerlyPoint::new()).collect();
+
+    // Main loop: find nearest centroids and recalculate means until convergence
+    loop {
+        C::compute_half_distances(&mut centers);
+        C::get_closest_centroid_hamerly(&buf, &centers, &mut points);
+        C::recalculate_centroids_hamerly(&mut rng, &buf, &mut centers, &points);
+
+        score = Calculate::check_loop(&centers.centroids, &old_centers);
+        if verbose {
+            println!("Score: {}", score);
+        }
+
+        // Verify that either the maximum iteration count has been met or the
+        // centroids haven't moved beyond a certain threshold since the
+        // previous iteration.
+        if iterations >= max_iter || score <= converge {
+            if verbose {
+                println!("Iterations: {}", iterations);
+            }
+            break;
+        }
+
+        C::update_bounds(&centers, &mut points);
+        old_centers.clone_from(&centers.centroids);
+        iterations += 1;
+    }
+
+    Kmeans {
+        score,
+        centroids: centers.centroids,
+        indices: points.iter().map(|x| x.index).collect(),
+    }
+}
+
+#[cfg(feature = "palette_color")]
+impl<Wp: WhitePoint> Hamerly for Lab<Wp> {
+    fn compute_half_distances(centers: &mut HamerlyCentroids<Self>) {
+        // Find each center's closest center
+        for i in 0..centers.centroids.len() {
+            let mut diff;
+            let mut min = f32::MAX;
+            for j in 0..centers.centroids.len() {
+                // Don't compare centroid to itself
+                if i == j {
+                    continue;
+                }
+                diff = Self::difference(
+                    &centers.centroids.get(i).unwrap(),
+                    &centers.centroids.get(j).unwrap(),
+                );
+                if diff < min {
+                    min = diff;
+                }
+            }
+            centers.half_distances[i] = min.sqrt() * 0.5;
+        }
+    }
+
+    fn get_closest_centroid_hamerly(
+        buffer: &[Self],
+        centers: &HamerlyCentroids<Self>,
+        points: &mut [HamerlyPoint],
+    ) {
+        for (i, val) in buffer.iter().enumerate() {
+            assert!(i < buffer.len());
+            // Assign max of lower bound and half distance to z
+            let z = centers
+                .half_distances
+                .get(points[i].index as usize)
+                .unwrap()
+                .max(points[i].lower_bound);
+
+            if points[i].upper_bound <= z {
+                continue;
+            }
+
+            // Tighten upper bound
+            points[i].upper_bound = Self::difference(
+                val,
+                centers.centroids.get(points[i].index as usize).unwrap(),
+            )
+            .sqrt();
+
+            if points[i].upper_bound <= z {
+                continue;
+            }
+
+            // Find the two closest centers to current point and their distances
+            if centers.centroids.len() < 2 {
+                continue;
+            }
+
+            let mut min1 = Self::difference(val, centers.centroids.get(0).unwrap());
+            let mut min2 = f32::MAX;
+            let mut c1 = 0;
+            for j in 1..centers.centroids.len() {
+                let diff = Self::difference(val, centers.centroids.get(j).unwrap());
+                if diff < min1 {
+                    min2 = min1;
+                    min1 = diff;
+                    c1 = j;
+                    continue;
+                }
+                if diff < min2 {
+                    min2 = diff;
+                }
+            }
+
+            if c1 as u8 != points[i].index {
+                points[i].index = c1 as u8;
+                points[i].upper_bound = min1.sqrt();
+            }
+            points[i].lower_bound = min2.sqrt();
+        }
+    }
+
+    fn recalculate_centroids_hamerly(
+        mut rng: &mut impl Rng,
+        buf: &[Self],
+        centers: &mut HamerlyCentroids<Self>,
+        points: &[HamerlyPoint],
+    ) {
+        for (idx, cent) in centers.centroids.iter_mut().enumerate() {
+            let mut l = 0.0;
+            let mut a = 0.0;
+            let mut b = 0.0;
+            let mut counter: u64 = 0;
+            for (point, color) in points.iter().zip(buf) {
+                if point.index == idx as u8 {
+                    l += color.l;
+                    a += color.a;
+                    b += color.b;
+                    counter += 1;
+                }
+            }
+            if counter != 0 {
+                let new_color = Lab {
+                    l: l / (counter as f32),
+                    a: a / (counter as f32),
+                    b: b / (counter as f32),
+                    white_point: core::marker::PhantomData,
+                };
+                centers.deltas[idx] = Self::difference(cent, &new_color).sqrt();
+                *cent = new_color;
+            } else {
+                let new_color = Self::create_random(&mut rng);
+                centers.deltas[idx] = Self::difference(cent, &new_color).sqrt();
+                *cent = new_color;
+            }
+        }
+    }
+
+    fn update_bounds(centers: &HamerlyCentroids<Self>, points: &mut [HamerlyPoint]) {
+        let mut delta_p = 0.0;
+        for c in centers.deltas.iter() {
+            if *c > delta_p {
+                delta_p = *c;
+            }
+        }
+
+        for i in 0..points.len() {
+            points[i].upper_bound += centers.deltas.get(points[i].index as usize).unwrap();
+            points[i].lower_bound -= delta_p;
+        }
+    }
+}
+
+#[cfg(feature = "palette_color")]
+impl Hamerly for Srgb {
+    fn compute_half_distances(centers: &mut HamerlyCentroids<Self>) {
+        // Find each center's closest center
+        for i in 0..centers.centroids.len() {
+            let mut diff;
+            let mut min = f32::MAX;
+            for j in 0..centers.centroids.len() {
+                // Don't compare centroid to itself
+                if i == j {
+                    continue;
+                }
+                diff = Self::difference(
+                    &centers.centroids.get(i).unwrap(),
+                    &centers.centroids.get(j).unwrap(),
+                );
+                if diff < min {
+                    min = diff;
+                }
+            }
+            centers.half_distances[i] = min.sqrt() * 0.5;
+        }
+    }
+
+    fn get_closest_centroid_hamerly(
+        buffer: &[Self],
+        centers: &HamerlyCentroids<Self>,
+        points: &mut [HamerlyPoint],
+    ) {
+        for (i, val) in buffer.iter().enumerate() {
+            assert!(i < buffer.len());
+            // Assign max of lower bound and half distance to z
+            let z = centers
+                .half_distances
+                .get(points[i].index as usize)
+                .unwrap()
+                .max(points[i].lower_bound);
+
+            if points[i].upper_bound <= z {
+                continue;
+            }
+
+            // Tighten upper bound
+            points[i].upper_bound = Self::difference(
+                val,
+                centers.centroids.get(points[i].index as usize).unwrap(),
+            )
+            .sqrt();
+
+            if points[i].upper_bound <= z {
+                continue;
+            }
+
+            // Find the two closest centers to current point and their distances
+            if centers.centroids.len() < 2 {
+                continue;
+            }
+
+            let mut min1 = Self::difference(val, centers.centroids.get(0).unwrap());
+            let mut min2 = f32::MAX;
+            let mut c1 = 0;
+            for j in 1..centers.centroids.len() {
+                let diff = Self::difference(val, centers.centroids.get(j).unwrap());
+                if diff < min1 {
+                    min2 = min1;
+                    min1 = diff;
+                    c1 = j;
+                    continue;
+                }
+                if diff < min2 {
+                    min2 = diff;
+                }
+            }
+
+            if c1 as u8 != points[i].index {
+                points[i].index = c1 as u8;
+                points[i].upper_bound = min1.sqrt();
+            }
+            points[i].lower_bound = min2.sqrt();
+        }
+    }
+
+    fn recalculate_centroids_hamerly(
+        mut rng: &mut impl Rng,
+        buf: &[Self],
+        centers: &mut HamerlyCentroids<Self>,
+        points: &[HamerlyPoint],
+    ) {
+        for (idx, cent) in centers.centroids.iter_mut().enumerate() {
+            let mut red = 0.0;
+            let mut green = 0.0;
+            let mut blue = 0.0;
+            let mut counter: u64 = 0;
+            for (point, color) in points.iter().zip(buf) {
+                if point.index == idx as u8 {
+                    red += color.red;
+                    green += color.green;
+                    blue += color.blue;
+                    counter += 1;
+                }
+            }
+            if counter != 0 {
+                let new_color = Srgb {
+                    red: red / (counter as f32),
+                    green: green / (counter as f32),
+                    blue: blue / (counter as f32),
+                    standard: core::marker::PhantomData,
+                };
+                centers.deltas[idx] = Self::difference(cent, &new_color).sqrt();
+                *cent = new_color;
+            } else {
+                let new_color = Self::create_random(&mut rng);
+                centers.deltas[idx] = Self::difference(cent, &new_color).sqrt();
+                *cent = new_color;
+            }
+        }
+    }
+
+    fn update_bounds(centers: &HamerlyCentroids<Self>, points: &mut [HamerlyPoint]) {
+        let mut delta_p = 0.0;
+        for c in centers.deltas.iter() {
+            if *c > delta_p {
+                delta_p = *c;
+            }
+        }
+
+        for i in 0..points.len() {
+            points[i].upper_bound += centers.deltas.get(points[i].index as usize).unwrap();
+            points[i].lower_bound -= delta_p;
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! # Overview
 //!
-//! This crate provides traits for calculating and implementing a k-means
+//! This crate provides traits for implementing and calculating a k-means
 //! clustering algorithm. The original implementation of this library was
 //! created for finding k-means colors in image buffers. Applications of crate
 //! functionality can be seen on the [README page][readme].
@@ -15,15 +15,21 @@
 //! `Srgb` color types behind the `palette_color` feature.
 //!
 //! The binary located in `src/bin/kmeans_colors` shows examples of crate
-//! functionality.
+//! usage.
 //!
 //! [palette]: https://github.com/Ogeon/palette/
 //!
 //! ## The `Calculate` trait
 //! k-means calculations can be provided for other data types by implementing
-//! the [`Calculate`](trait.Calculate.html) trait. See the `Lab` and `Srgb`
-//! implementations in [`kmeans.rs`](../src/kmeans_colors/kmeans.rs.html#119)
-//! for examples.
+//! the [`Calculate`](trait.Calculate.html) trait. Further,
+//! [`Hamerly`](trait.Hamerly.html) can be implemented to enable use of the
+//! Hamerly optimization and [`get_kmeans_hamerly`][hamerly]. See the `Lab` and
+//! `Srgb` implementations in [`kmeans.rs`][kmeans] for examples. These
+//! implementations can be used as groundwork for implementing with other types,
+//! and should not require much modification beyond the distance calculations.
+//!
+//! [hamerly]: fn.get_kmeans_hamerly.html
+//! [kmeans]: ../src/kmeans_colors/kmeans.rs.html#119
 //!
 //! ## Calculating k-means with `palette_color`
 //!
@@ -165,5 +171,7 @@ mod sort;
 #[cfg(feature = "palette_color")]
 pub use kmeans::MapColor;
 
-pub use kmeans::{get_kmeans, Calculate, Kmeans};
+pub use kmeans::{
+    get_kmeans, get_kmeans_hamerly, Calculate, Hamerly, HamerlyCentroids, HamerlyPoint, Kmeans,
+};
 pub use sort::{CentroidData, Sort};

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 use crate::Calculate;
 
-/// A struct containing a centroid, its percentage within a buffer, and the
+/// Struct containing a centroid, its percentage within a buffer, and the
 /// centroid's index.
 #[derive(Clone, Debug, Default)]
 pub struct CentroidData<C: Calculate> {


### PR DESCRIPTION
Reformat README.md.
Add logic for adaptive switching between Hamerly and naive in the binary.

`k=6` seems to be the crossover point for colors when it's advantageous to use Hamerly over naive in the average case. This is not the case in the lanterns example: there are many similar colors, so distance calculations end up being performed and the overhead of the cached distance results likely slows down calculation. The flowers example has clear winnings probably attributable to cleaner segmentation of colors. Seconds can come off the calculation because of early convergence in the best case images skipping distance calculations for many points. The binary uses the optimization for `k>5`, the performance lost in some cases should be recovered by the next version of `palette` with optimization of converting between floats/ints and Rgb/Lab.

Implementation note:
Square roots were necessary for the bounds calculation to result in the same calculation of colors as the naive version. The algorithms should be deterministic and result in the same colors. Tests should be added to verify this stays the case automatically instead of human-verifying.

Reference:
Hamerly, G., & Drake, J. (2017). Chapter 2 Accelerating Lloyd's Algorithm for k-Means Clustering.
Hamerly, G. (2010). Making k-means even faster. In: SIAM international conference on data
mining.

Closes #1 