### PR TITLE
Implement kmeans++ for better centroid initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,13 @@
 [![Crates.io](https://img.shields.io/crates/v/kmeans-colors.svg)](https://crates.io/crates/kmeans-colors)
 [![Docs.rs](https://docs.rs/kmeans_colors/badge.svg)](https://docs.rs/kmeans_colors)
 
-Calculate the `k` average colors in an image using k-means clustering.
+Calculate the `k` average colors in an image using k-means clustering with
+k-means++ initialization.
 
 k-means can find the dominant colors or color palette of an image. Other
-applications in this crate are binarization, line extraction, and "color style"
-transfer. The crate wraps around a generic [k-means implementation][lib] that 
-supports Lloyd's and Hamerly's algorithms for arbitrary data types.
+applications in this crate are binarization and "color style" transfer. The
+crate wraps around a generic [k-means implementation][lib] that supports Lloyd's
+and Hamerly's algorithms for arbitrary data types.
 
 [lib]: https://docs.rs/kmeans_colors/
 
@@ -205,8 +206,8 @@ the results.
 - print the average colors
 - print the percentage of each color in the image
 - transparency support
-- adaptive switching between LLoyd's and Hamerly's algorithms based on `k` count
-- supports multiple images as input to process
+- kmeans++ center initialization
+- supports multiple images as input to batch process
 - specify random seed for reproducible results
 
 ## License

--- a/src/bin/kmeans_colors/app.rs
+++ b/src/bin/kmeans_colors/app.rs
@@ -52,7 +52,7 @@ pub fn run(opt: Opt) -> Result<(), Box<dyn Error>> {
 
             // Iterate over amount of runs keeping best results
             let mut result = Kmeans::new();
-            if opt.k > 5 {
+            if opt.k > 1 {
                 (0..opt.runs).for_each(|i| {
                     let run_result = get_kmeans_hamerly(
                         opt.k as usize,
@@ -185,7 +185,7 @@ pub fn run(opt: Opt) -> Result<(), Box<dyn Error>> {
 
             // Iterate over amount of runs keeping best results
             let mut result = Kmeans::new();
-            if opt.k > 5 {
+            if opt.k > 1 {
                 (0..opt.runs).for_each(|i| {
                     let run_result = get_kmeans_hamerly(
                         opt.k as usize,
@@ -403,7 +403,7 @@ pub fn find_colors(
 
                 let mut result = Kmeans::new();
                 let k = centroids.len();
-                if k > 5 {
+                if k > 1 {
                     (0..runs).for_each(|i| {
                         let run_result = get_kmeans_hamerly(
                             k,
@@ -527,7 +527,7 @@ pub fn find_colors(
 
                 let mut result = Kmeans::new();
                 let k = centroids.len();
-                if k > 5 {
+                if k > 1 {
                     (0..runs).for_each(|i| {
                         let run_result = get_kmeans_hamerly(
                             k,

--- a/src/kmeans.rs
+++ b/src/kmeans.rs
@@ -5,6 +5,8 @@ use palette::{Component, Lab, Laba, Srgb, Srgba};
 
 use rand::{Rng, SeedableRng};
 
+use crate::plus_plus::init_plus_plus;
+
 /// A trait for enabling k-means calculation of a data type.
 pub trait Calculate: Sized {
     /// Find a points's nearest centroid, index the point with that centroid.
@@ -76,7 +78,7 @@ pub fn get_kmeans<C: Calculate + Clone>(
     // Initialize the random centroids
     let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
     let mut centroids: Vec<C> = Vec::with_capacity(k);
-    (0..k).for_each(|_| centroids.push(C::create_random(&mut rng)));
+    init_plus_plus(k, &mut rng, buf, &mut centroids);
 
     // Initialize indexed buffer and convergence variables
     let mut iterations = 0;
@@ -382,7 +384,7 @@ pub fn get_kmeans_hamerly<C: Hamerly + Clone>(
     // Initialize the random centroids
     let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
     let mut centers: HamerlyCentroids<C> = HamerlyCentroids::new(k);
-    (0..k).for_each(|_| centers.centroids.push(Calculate::create_random(&mut rng)));
+    init_plus_plus(k, &mut rng, buf, &mut centers.centroids);
 
     // Initialize points buffer and convergence variables
     let mut iterations = 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,6 +166,7 @@
 //! ```
 
 mod kmeans;
+mod plus_plus;
 mod sort;
 
 #[cfg(feature = "palette_color")]
@@ -174,4 +175,5 @@ pub use kmeans::MapColor;
 pub use kmeans::{
     get_kmeans, get_kmeans_hamerly, Calculate, Hamerly, HamerlyCentroids, HamerlyPoint, Kmeans,
 };
+pub use plus_plus::init_plus_plus;
 pub use sort::{CentroidData, Sort};

--- a/src/plus_plus.rs
+++ b/src/plus_plus.rs
@@ -1,0 +1,51 @@
+use rand::distributions::{Distribution, WeightedIndex};
+use rand::Rng;
+
+use crate::Calculate;
+
+/// k-means++ centroid initialization.
+///
+/// Based on Section 2.2 from `k-means++: The Advantages of Careful Seeding` by
+/// Arthur and Vassilvitskii (2007).
+pub fn init_plus_plus<C: Calculate + Clone>(
+    k: usize,
+    mut rng: &mut impl Rng,
+    buf: &[C],
+    centroids: &mut Vec<C>,
+) {
+    if k == 0 {
+        return;
+    }
+
+    let len = buf.len();
+    let mut weights: Vec<f32> = (0..len).map(|_| 0.0).collect();
+
+    // Choose first centroid at random, uniform sampling from input buffer
+    centroids.push(buf.get(rng.gen_range(0, len)).unwrap().to_owned());
+
+    // Pick a new centroid with weighted probability of `D(x)^2 / sum(D(x)^2)`,
+    // where `D(x)^2` is the distance to the closest centroid
+    (1..k).for_each(|_| {
+        // Calculate the distances to nearest centers, accumulate a sum
+        let mut sum = 0.0;
+        for (b, dist) in buf.iter().zip(weights.iter_mut()) {
+            let mut diff;
+            let mut min = core::f32::MAX;
+            for cent in centroids.iter() {
+                diff = C::difference(b, cent);
+                if diff < min {
+                    min = diff;
+                }
+            }
+            *dist = min;
+            sum += min;
+        }
+
+        // Divide distances by sum to find D^2 weighting for distribution
+        weights.iter_mut().for_each(|x| *x /= sum);
+
+        // Choose next centroid based on weights
+        let sampler = WeightedIndex::new(&weights).unwrap();
+        centroids.push(buf.get(sampler.sample(&mut rng)).unwrap().to_owned());
+    });
+}


### PR DESCRIPTION
Change library kmeans algorithms to kmeans++ random initialization
Change binary to use Hamerly for k greater than 1

k-means++ provides much faster results across the board and slightly less error in many cases. However, this changes the behavior from the previous implementation. 