### PR TITLE
Fix bugs introduced by switch to kmeans++, update documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # `kmeans-colors` changelog
 
+## Version 0.3.2 - 2020-06-03
+
+Bug fix for k-means++ to avoid divide by zero errors and panics with rand.
+
+[#23][23] - Fix bugs introduced by switch to kmeans++  
+
 ## Version 0.3.1 - 2020-06-03
 
 Major performance improvements in the form of algorithmic
@@ -40,6 +46,7 @@ performance to color and format conversions.
 ## Version 0.1.0 - 2020-04
 * Initial Commit
 
+[23]: https://github.com/okaneco/kmeans-colors/pull/23
 [20]: https://github.com/okaneco/kmeans-colors/pull/20
 [18]: https://github.com/okaneco/kmeans-colors/pull/18
 [16]: https://github.com/okaneco/kmeans-colors/pull/16

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "kmeans_colors"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "image",
  "palette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kmeans_colors"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["okaneco <47607823+okaneco@users.noreply.github.com>"]
 edition = "2018"
 exclude = ["test", "gfx"]
@@ -10,7 +10,7 @@ readme = "README.md"
 keywords = ["kmeans", "clustering", "lab", "color", "rgb"]
 categories = ["graphics", "multimedia::images", "mathematics"]
 license = "MIT OR Apache-2.0"
-description = """Simple k-means clustering to find dominant colors in images.\n
+description = """Simple k-means clustering to find dominant colors in images.
 Backed by a generic k-means implementation offered as a standalone library."""
 
 [features]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ that color. This process repeats until the centroids stop moving or the maximum
 step count is reached.
 
 ```
-kmeans_colors -i gfx/pink.jpg -k 2 -r 3 -o pink2
+kmeans_colors -i gfx/pink.jpg -k 2 -o pink2
 ```
 
 The animation above is a composite of k=2 to k=9 k-means with the preceding
@@ -55,21 +55,22 @@ image. The default sorting method is from darkest to lightest, passing `--sort`
 will rearrange the palette in order from most frequent to least frequent color.
 The `--height` and `--width` of the palette can be specified as well as output
 name with `--op`. Passing `-k 1` will produce the average color of the image.
+`--no-file` is passed to bypass saving the result of the original image.
 
 ## 3) The `find` subcommand
 
 ### a) Binary Ferris Example
 
 We can use k-means to clean up this doodle and extract the line work from it.
-The paper this is on is folded and scribbled over with highlighter and 
-blue pencil, the back of the sheet also has ink on it.
+The paper this is on is folded and scribbled over with highlighter and blue
+pencil, the back of the sheet also has ink on it.
 
 ![Drawing of Ferris the crab with highlighter](gfx/ferris.jpg)
 
 ---
 
 ```
-kmeans_colors -i gfx/ferris.jpg -k 2 -r 3 -o gfx/ferris-2color.png
+kmeans_colors -i gfx/ferris.jpg -k 2 -o gfx/ferris-2color.png
 ```
 ![Yellow highlighter on paper](gfx/ferris-2color.png)
 
@@ -79,7 +80,7 @@ the highlighter and the average of the ink and paper.
 ---
 
 ```
-kmeans_colors -i gfx/ferris.jpg -k 3 -r 3 -o gfx/ferris-3color.png
+kmeans_colors -i gfx/ferris.jpg -k 3 -o gfx/ferris-3color.png
 ```
 ![Crab drawing with 3 colors](gfx/ferris-3color.png)
 
@@ -114,7 +115,7 @@ right. Running the following command prints the 12 colors below in order from
 darkest to lightest in hexadecimal.
 
 ```
-kmeans_colors -i gfx/flowers.jpg -r 3 -p -k 12 --no-file
+kmeans_colors -i gfx/flowers.jpg -p -k 12 --no-file
 ```
 ```
 492f38,6c363e,8d444e,ae525b,8c6779,677a9b,b87078,4b95bb,a499b0,d7969d,e3b8c0,c5c6da
@@ -166,17 +167,15 @@ score gets smaller as the colors converge. This can be helpful for
 troubleshooting if results are unexpected since the k-means may not have
 converged. The `-p` flag prints the colors in hexadecimal ordered from darkest
 to brightest as seen below. The `--pct` flag prints the percentage of each color
-present in the result image. Finally, `--no-file` can be passed in order to
-avoid writing out a result image.
+present in the resulting image.
 
 ```
 gfx/pink.jpg
-Score: 37370.32
-Score: 18.397617
-Score: 0.2376602
-Iterations: 2
-4d5f60,dd5d5b
-0.6613,0.3387
+Score: 62.90416
+Score: 0.05048233
+Iterations: 1
+4e5f60,dc5d5c
+0.6605,0.3395
 ```
 
 ## *Usage Notes:*
@@ -186,11 +185,6 @@ the process and keep the best result. The `-m` flag can be used to specify the
 max amount of iterations to perform. Lastly, the convergence factor can be
 specified with `-f`. Larger image files will take longer to complete so
 defaults were carefully selected for each of these.
-
-A conservative setting of `-r 3 -m 40` nearly ensures convergence with Lab for
-smaller `k` values (below ~40) in a reasonable amount of time. Finding the
-`--rgb` k-means converges very quickly and tends to happen in under 10
-iterations for small `k`.
 
 The `--transparent` flag can be passed when working with transparent PNG images.
 The k-means will be calculated without factoring in any pixels with

--- a/src/bin/kmeans_colors/app.rs
+++ b/src/bin/kmeans_colors/app.rs
@@ -29,7 +29,7 @@ pub fn run(opt: Opt) -> Result<(), Box<dyn Error>> {
         match opt.factor {
             Some(x) => converge = x,
             None => {
-                converge = if !opt.rgb { 10.0 } else { 0.0025 };
+                converge = if !opt.rgb { 5.0 } else { 0.0025 };
             }
         }
 
@@ -328,7 +328,7 @@ pub fn find_colors(
     match factor {
         Some(x) => converge = x,
         None => {
-            converge = if !rgb { 8.0 } else { 0.0025 };
+            converge = if !rgb { 5.0 } else { 0.0025 };
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,18 +98,16 @@
 //! # assert_eq!(Srgb::into_raw_slice(&buffer), [119, 119, 119, 119, 119, 119]);
 //! ```
 //!
-//! Because the initial seeds are random, the k-means calculation should be run
-//! multiple times in order to assure that the best result has been found. The
-//! algorithm may find itself in local minima that is not the optimal result.
-//! This is especially true for `Lab` but `Srgb` may only need one run.
+//! k-means++ is used for centroid initialization. Because the initialization is
+//! random, the k-means calculation may be run multiple times to assure that
+//! the best result has been found. The algorithm can find itself in a
+//! sub-optimal result due to initial centroids.
 //!
-//! The binary uses `8` as the default `k`. The iteration limit is set to `20`,
-//! RGB usually converges in under 10 iterations depending on the `k`. The
-//! convergence factor defaults to `10.0` for `Lab` and `0.0025` for `Srgb`. The
-//! number of runs defaults to `3` for one of the binary subcommands. Through
-//! testing, these numbers were found to be an adequate trade-off between
-//! performance and accuracy. If the results do not appear correct, raise the
-//! iteration limit as convergence was probably not met.
+//! The binary uses `8` as the default `k`. The iteration limit is set to `20`.
+//! The convergence factor defaults to `5.0` for `Lab` and `0.0025` for `Srgb`.
+//! The number of runs defaults to `3` for one of the binary subcommands.
+//! If the results do not appear correct, raise the iteration limit as
+//! convergence was probably not met.
 //!
 //! ### Getting the dominant color
 //!

--- a/src/plus_plus.rs
+++ b/src/plus_plus.rs
@@ -5,6 +5,12 @@ use crate::Calculate;
 
 /// k-means++ centroid initialization.
 ///
+/// # Panics
+///
+/// Panics if buffer is empty.
+///
+/// # Reference
+///
 /// Based on Section 2.2 from `k-means++: The Advantages of Careful Seeding` by
 /// Arthur and Vassilvitskii (2007).
 pub fn init_plus_plus<C: Calculate + Clone>(
@@ -16,8 +22,9 @@ pub fn init_plus_plus<C: Calculate + Clone>(
     if k == 0 {
         return;
     }
-
     let len = buf.len();
+    assert!(len > 0);
+
     let mut weights: Vec<f32> = (0..len).map(|_| 0.0).collect();
 
     // Choose first centroid at random, uniform sampling from input buffer
@@ -39,6 +46,11 @@ pub fn init_plus_plus<C: Calculate + Clone>(
             }
             *dist = min;
             sum += min;
+        }
+
+        // If centroids match all colors, return
+        if !sum.is_normal() {
+            return;
         }
 
         // Divide distances by sum to find D^2 weighting for distribution

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -55,6 +55,7 @@ impl<Wp: WhitePoint> Sort for Lab<Wp> {
         }
 
         let len = indices.len();
+        assert!(len > 0);
         let mut colors: Vec<(u8, f32)> = Vec::with_capacity(centroids.len());
         for (i, _) in centroids.iter().enumerate() {
             let count = map.get(&(i as u8));
@@ -117,6 +118,7 @@ impl Sort for Srgb {
         }
 
         let len = indices.len();
+        assert!(len > 0);
         let mut colors: Vec<(u8, f32)> = Vec::with_capacity(centroids.len());
         for (i, _) in centroids.iter().enumerate() {
             let count = map.get(&(i as u8));


### PR DESCRIPTION
Possible divide by zero if buffer is filled with one value.
Add assert that buffer length is greater than 0.
Update documentation to remove references to pre-optimized settings.
Reduce convergence factor for Lab to 5.0 for better results.