### PR TITLE
Update crate version to 0.4.0, rand to 0.8, rand_chacha to 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
  "cfg-if",
  "libc",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "kmeans_colors"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "image",
  "palette",
@@ -283,22 +283,20 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
 dependencies = [
- "getrandom",
  "libc",
  "rand_chacha",
  "rand_core",
- "rand_hc",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -306,20 +304,11 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.5.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core",
 ]
 
 [[package]]
@@ -392,6 +381,6 @@ checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kmeans_colors"
-version = "0.3.4"
+version = "0.4.0"
 authors = ["okaneco <47607823+okaneco@users.noreply.github.com>"]
 edition = "2018"
 exclude = ["test", "gfx", ".github"]
@@ -40,12 +40,12 @@ features = ["std"]
 optional = true
 
 [dependencies.rand]
-version = "0.7"
+version = "0.8"
 default-features = false
 features = ["std"]
 
 [dependencies.rand_chacha]
-version = "0.2"
+version = "0.3"
 default-features = false
 
 [dependencies.structopt]

--- a/src/colors/kmeans.rs
+++ b/src/colors/kmeans.rs
@@ -71,9 +71,9 @@ impl<Wp: palette::white_point::WhitePoint> Calculate for Lab<Wp> {
     #[inline]
     fn create_random(rng: &mut impl Rng) -> Lab<Wp> {
         Lab::with_wp(
-            rng.gen_range(0.0, 100.0),
-            rng.gen_range(-128.0, 127.0),
-            rng.gen_range(-128.0, 127.0),
+            rng.gen_range(0.0..=100.0),
+            rng.gen_range(-128.0..=127.0),
+            rng.gen_range(-128.0..=127.0),
         )
     }
 

--- a/src/plus_plus.rs
+++ b/src/plus_plus.rs
@@ -26,7 +26,7 @@ pub fn init_plus_plus<C: crate::Calculate + Clone>(
     let mut weights: Vec<f32> = (0..len).map(|_| 0.0).collect();
 
     // Choose first centroid at random, uniform sampling from input buffer
-    centroids.push(buf.get(rng.gen_range(0, len)).unwrap().to_owned());
+    centroids.push(buf.get(rng.gen_range(0..len)).unwrap().to_owned());
 
     // Pick a new centroid with weighted probability of `D(x)^2 / sum(D(x)^2)`,
     // where `D(x)^2` is the distance to the closest centroid


### PR DESCRIPTION
This should enable projects with rand 0.8 to implement `Calculate`.