### PR TITLE
Update metadata for 0.5 release; CI/CD, clippy, `image` fixups

### DIFF
--- a/.github/workflows/rust-cd.yml
+++ b/.github/workflows/rust-cd.yml
@@ -62,32 +62,16 @@ jobs:
           toolchain: ${{ matrix.rust }}
           args: --release --target ${{ matrix.platform.target }}
 
-      - name: Install strip command
-        if: ${{ matrix.platform.target == 'aarch64-unknown-linux-gnu' }}
-        shell: bash
-        run: |
-          sudo apt update
-          sudo apt-get install -y binutils-aarch64-linux-gnu
-
       - name: Package final binary
         shell: bash
         run: |
           cd target/${{ matrix.platform.target }}/release
-          ####### reduce binary size by removing debug symbols #######
           BINARY_NAME=kmeans_colors${{ matrix.platform.binary-postfix }}
-          if [[ ${{ matrix.platform.target }} == aarch64-unknown-linux-gnu ]]; then
-            GCC_PREFIX="aarch64-linux-gnu-"
-          else
-            GCC_PREFIX=""
-          fi
-
-          if [[ ${{ matrix.platform.target }} != x86_64-pc-windows-msvc ]]; then
-            "$GCC_PREFIX"strip $BINARY_NAME
-          fi
 
           ########## create tar.gz ##########
           RELEASE_NAME=kmeans_colors-${GITHUB_REF/refs\/tags\//}-${{ matrix.platform.os-name }}-${{ matrix.platform.architecture }}
           tar czvf $RELEASE_NAME.tar.gz $BINARY_NAME
+
           ########## create sha256 ##########
           if [[ ${{ runner.os }} == 'Windows' ]]; then
             certutil -hashfile $RELEASE_NAME.tar.gz sha256 | grep -E [A-Fa-f0-9]{64} > $RELEASE_NAME.sha256

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Doc tests (palette feature)
         run: cargo test --no-default-features --doc --features palette_color
       - name: Build docs
-        run: cargo doc --no-deps
+        run: cargo doc --no-deps --no-default-features --features palette_color
 
   clippy-rustfmt:
     name: Clippy and rustfmt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # `kmeans-colors` changelog
 
+## Version 0.5.0 - 2022-03-17
+
+Version bump for updating `palette` to `0.6`.
+
+No changes to library code.
+
+[#49][49] - Update metadata for 0.5 release; CI/CD, clippy, and `image` fixups  
+[#44][44] - Upgrade `palette` to 0.6, fix clippy lints, `image` function fixups
+
 ## Version 0.4.0 - 2021-03-13
 
 Version bump for updating the `rand` dependency to 0.8. No major API changes.
@@ -75,6 +84,8 @@ performance to color and format conversions.
 ## Version 0.1.0 - 2020-04
 * Initial Commit
 
+[49]: https://github.com/okaneco/kmeans-colors/pull/49
+[44]: https://github.com/okaneco/kmeans-colors/pull/44
 [41]: https://github.com/okaneco/kmeans-colors/pull/41
 [40]: https://github.com/okaneco/kmeans-colors/pull/40
 [36]: https://github.com/okaneco/kmeans-colors/pull/36

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "adler32"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,18 +16,18 @@ checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "approx"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "072df7202e63b127ab55acfe16ce97013d5b97bf160489336d3f1840fd78e99e"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bitflags"
@@ -31,9 +37,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bytemuck"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72957246c41db82b8ef88a5486143830adeb8227ef9837740bdec67724cf2c5b"
+checksum = "0e851ca7c24871e7336801608a4797d7376545b6928a10d32d75685687141ead"
 
 [[package]]
 name = "byteorder"
@@ -49,9 +55,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "bitflags",
  "textwrap",
@@ -66,21 +72,20 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "crc32fast"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "deflate"
-version = "0.8.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73770f8e1fe7d64df17ca66ad28994a0a623ea497fa69486e14984e715c5d174"
+checksum = "c86f7e25f518f4b81808a2cf1c50996a61f5c2eb394b2393bd87f2a4780a432f"
 dependencies = [
  "adler32",
- "byteorder",
 ]
 
 [[package]]
@@ -94,9 +99,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
 dependencies = [
  "cfg-if",
  "libc",
@@ -114,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.23.14"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ffcb7e7244a9bf19d35bf2883b9c080c4ced3c07a9895572178cdb8f13f6a1"
+checksum = "db207d030ae38f1eb6f240d5a1c1c88ff422aa005d10f8c6c6fc5e75286ab30e"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -130,13 +135,13 @@ dependencies = [
 
 [[package]]
 name = "jpeg-decoder"
-version = "0.1.22"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229d53d58899083193af11e15917b5640cd40b29ff475a1fe4ef725deb02d0f2"
+checksum = "105fb082d64e2100074587f59a74231f771750c664af903f1f9f76c9dedfc6f1"
 
 [[package]]
 name = "kmeans_colors"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "image",
  "palette",
@@ -153,17 +158,17 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.103"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
+checksum = "ad5c14e80759d0939d013e6ca49930e59fc53dd8e5009132f76240c179380c09"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.3.7"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
+checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
 dependencies = [
- "adler32",
+ "adler",
 ]
 
 [[package]]
@@ -189,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
+checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -232,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "png"
-version = "0.16.8"
+version = "0.17.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3287920cb847dee3de33d301c463fba14dda99db24214ddf93f83d3021f4c6"
+checksum = "dc38c0ad57efb786dd57b9864e5b18bae478c00c824dc55a38bbc9da95dde3ba"
 dependencies = [
  "bitflags",
  "crc32fast",
@@ -244,9 +249,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.10"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro-error"
@@ -274,27 +279,27 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.29"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -322,15 +327,15 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.130"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 
 [[package]]
 name = "structopt"
-version = "0.3.23"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf9d950ef167e25e0bdb073cf1d68e9ad2795ac826f2f3f59647817cf23c0bfa"
+checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
  "clap",
  "lazy_static",
@@ -339,9 +344,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134d838a2c9943ac3125cf6df165eda53493451b719f3255b2a26b85f772d0ba"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -352,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.78"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4eac2e6c19f5c3abc0c229bea31ff0b9b091c7b14990e8924b92902a303a0c0"
+checksum = "ea297be220d52398dcc07ce15a209fce436d361735ac1db700cab3b6cdfb9f54"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -381,9 +386,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-width"
@@ -399,9 +404,9 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kmeans_colors"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["okaneco <47607823+okaneco@users.noreply.github.com>"]
 edition = "2018"
 exclude = ["test", "gfx", ".github"]
@@ -28,33 +28,33 @@ app = [
 palette_color = ["palette"]
 
 [dependencies.image]
-version = "0.23"
+version = "0.24.1"
 default-features = false
 features = ["jpeg", "png"]
 optional = true
 
 [dependencies.palette]
-version = "0.6"
+version = "0.6.0"
 default-features = false
 features = ["std"]
 optional = true
 
 [dependencies.rand]
-version = "0.8"
+version = "0.8.5"
 default-features = false
 features = ["std"]
 
 [dependencies.rand_chacha]
-version = "0.3"
+version = "0.3.1"
 default-features = false
 
 [dependencies.structopt]
-version = "0.3"
+version = "0.3.26"
 default-features = false
 optional = true
 
 [profile.release]
-lto = "thin"
+strip = true
 
 [package.metadata.docs.rs]
 no-default-features = true

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ be found at https://github.com/okaneco/kmeans-colors/releases.
 
 ```toml
 [dependencies.kmeans_colors]
-version = "0.4"
+version = "0.5"
 default-features = false
 ```
 

--- a/src/bin/kmeans_colors/filename.rs
+++ b/src/bin/kmeans_colors/filename.rs
@@ -12,8 +12,7 @@ pub fn create_filename(
     k: Option<u8>,
     file: &Path,
 ) -> Result<PathBuf, CliError> {
-    let title;
-    if input.len() == 1 {
+    let title = if input.len() == 1 {
         match output {
             Some(x) => {
                 let mut temp = x.clone();
@@ -23,12 +22,12 @@ pub fn create_filename(
                         temp.set_extension(extension);
                     }
                 }
-                title = temp;
+                temp
             }
             None => {
                 let mut temp = PathBuf::from(generate_filename(file, k)?);
                 temp.set_extension(extension);
-                title = temp;
+                temp
             }
         }
     } else {
@@ -36,29 +35,24 @@ pub fn create_filename(
             Some(x) => {
                 let mut temp = x.clone();
                 let clone = temp.clone();
-                let ext;
-                match clone.extension() {
-                    Some(y) => {
-                        ext = y.to_str().unwrap();
-                    }
-                    None => {
-                        ext = extension;
-                    }
-                }
+                let ext = match clone.extension() {
+                    Some(y) => y.to_str().unwrap(),
+                    None => extension,
+                };
                 temp.set_file_name(format!(
                     "{}-{}",
                     &file.file_stem().unwrap().to_str().unwrap(),
                     &temp.file_stem().unwrap().to_str().unwrap()
                 ));
-                title = temp.with_extension(ext);
+                temp.with_extension(ext)
             }
             None => {
                 let mut temp = PathBuf::from(generate_filename(file, k)?);
                 temp.set_extension(extension);
-                title = temp;
+                temp
             }
         }
-    }
+    };
 
     Ok(title)
 }
@@ -71,9 +65,8 @@ pub fn create_filename_palette(
     k: Option<u8>,
     file: &Path,
 ) -> Result<PathBuf, CliError> {
-    let title;
     let extension = "png";
-    if input.len() == 1 {
+    let title = if input.len() == 1 {
         match output {
             Some(x) => {
                 let mut temp = x.clone();
@@ -83,12 +76,12 @@ pub fn create_filename_palette(
                         temp.set_extension(extension);
                     }
                 }
-                title = temp;
+                temp
             }
             None => {
                 let mut temp = PathBuf::from(generate_filename_palette(file, k.unwrap(), rgb)?);
                 temp.set_extension(extension);
-                title = temp;
+                temp
             }
         }
     } else {
@@ -96,29 +89,24 @@ pub fn create_filename_palette(
             Some(x) => {
                 let mut temp = x.clone();
                 let clone = temp.clone();
-                let ext;
-                match clone.extension() {
-                    Some(y) => {
-                        ext = y.to_str().unwrap();
-                    }
-                    None => {
-                        ext = extension;
-                    }
-                }
+                let ext = match clone.extension() {
+                    Some(y) => y.to_str().unwrap(),
+                    None => extension,
+                };
                 temp.set_file_name(format!(
                     "{}-{}",
                     &file.file_stem().unwrap().to_str().unwrap(),
                     &temp.file_stem().unwrap().to_str().unwrap()
                 ));
-                title = temp.with_extension(ext);
+                temp.with_extension(ext)
             }
             None => {
                 let mut temp = PathBuf::from(generate_filename_palette(file, k.unwrap(), rgb)?);
                 temp.set_extension(extension);
-                title = temp;
+                temp
             }
         }
-    }
+    };
 
     Ok(title)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@
 //! // An image buffer of one black pixel and one white pixel
 //! let img_vec = [0u8, 0, 0, 255, 255, 255];
 //!
-//! # let runs = 3;
+//! # let runs = 1;
 //! # let k = 1;
 //! # let max_iter = 20;
 //! # let converge = 8.0;
@@ -96,6 +96,28 @@
 //!     .collect::<Vec<Srgb<u8>>>();
 //! let buffer = Srgb::map_indices_to_centroids(&rgb, &result.indices);
 //! # assert_eq!(Srgb::into_raw_slice(&buffer), [119, 119, 119, 119, 119, 119]);
+//! # // Test get_kmeans_hamerly
+//! # let mut result = Kmeans::new();
+//! # for i in 0..runs {
+//! #     let run_result = kmeans_colors::get_kmeans_hamerly(
+//! #         k,
+//! #         max_iter,
+//! #         converge,
+//! #         verbose,
+//! #         &lab,
+//! #         seed + i as u64,
+//! #     );
+//! #     if run_result.score < result.score {
+//! #         result = run_result;
+//! #     }
+//! # }
+//! # // Convert indexed colors back to Srgb<u8> for output
+//! # let rgb = &result.centroids
+//! #     .iter()
+//! #     .map(|x| Srgb::from_color(*x).into_format())
+//! #     .collect::<Vec<Srgb<u8>>>();
+//! # let buffer = Srgb::map_indices_to_centroids(&rgb, &result.indices);
+//! # assert_eq!(Srgb::into_raw_slice(&buffer), [119, 119, 119, 119, 119, 119]);
 //! ```
 //!
 //! k-means++ is used for centroid initialization. Because the initialization is
@@ -118,13 +140,13 @@
 //! lightest and returns an array of [`CentroidData`](struct.CentroidData.html).
 //!
 //! [sort]: trait.Sort.html#tymethod.sort_indexed_colors
-//! ```no_run
+//! ```
 //! # use palette::{FromColor, IntoColor, Lab, Pixel, Srgb};
 //! # use kmeans_colors::{get_kmeans, Kmeans};
 //! use kmeans_colors::Sort;
 //!
 //! # let img_vec = [0u8, 0, 0, 255, 255, 255];
-//! # let runs = 3;
+//! # let runs = 1;
 //! # let k = 1;
 //! # let max_iter = 20;
 //! # let converge = 8.0;


### PR DESCRIPTION
Update `image` crate to 0.24, fix deprecation of PngEncoder::encode
Remove strip from CD due to cargo strip stabilization
Make CI test cargo doc build with palette_color feature
Add get_kmeans_hamerly test to lib.rs doctest
Fix clippy lints for late init, this shortens code overall
Change ImageBuffer calls to as_raw where possible, removes an allocation
Save palette files with Adaptive filtering to save more space
Update Cargo.lock
Specify more precise dependencies in Cargo.toml
Strip symbols in release in Cargo.toml
Update version number in README.md
Update changelog