### PR TITLE
Upgrade palette to 0.7, bump crate version to 0.6, update CI/CD workflow

### DIFF
--- a/.github/workflows/rust-cd.yml
+++ b/.github/workflows/rust-cd.yml
@@ -9,58 +9,32 @@ jobs:
   publish-binary:
     runs-on: ${{ matrix.platform.os }}
     strategy:
+      fail-fast: false
       matrix:
-        rust: [ stable ]
         platform:
           - os: macos-latest
             os-name: macos
             target: x86_64-apple-darwin
             architecture: x86_64
             binary-postfix: ""
-            use-cross: false
           - os: ubuntu-latest
             os-name: linux
             target: x86_64-unknown-linux-gnu
             architecture: x86_64
             binary-postfix: ""
-            use-cross: false
           - os: windows-latest
             os-name: windows
             target: x86_64-pc-windows-msvc
             architecture: x86_64
             binary-postfix: ".exe"
-            use-cross: false
-          - os: ubuntu-latest
-            os-name: linux
-            target: aarch64-unknown-linux-gnu
-            architecture: arm64
-            binary-postfix: ""
-            use-cross: true
-          - os: ubuntu-latest
-            os-name: linux
-            target: i686-unknown-linux-gnu
-            architecture: i686
-            binary-postfix: ""
-            use-cross: true
 
     steps:
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          profile: minimal
-          override: true
-
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cargo build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          use-cross: ${{ matrix.platform.use-cross }}
-          toolchain: ${{ matrix.rust }}
-          args: --release --target ${{ matrix.platform.target }}
+        uses: dtolnay/rust-toolchain@stable
+        run: cargo build -v --release --target ${{ matrix.platform.target }}
 
       - name: Package final binary
         shell: bash

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -15,22 +15,18 @@ env:
 jobs:
   build-crate:
     name: Build and test crate/docs
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu, windows, macos]
         toolchain: [nightly, beta, stable]
-        include:
-          - os: macos-latest
-            toolchain: stable
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.toolchain }}
           components: rust-docs
-          override: true
       - name: Build library
         run: cargo build -v --lib --no-default-features
       - name: Build binary
@@ -45,14 +41,12 @@ jobs:
   clippy-rustfmt:
     name: Clippy and rustfmt
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
           components: clippy, rustfmt
-          override: true
       - name: clippy
         run: cargo clippy
         continue-on-error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # `kmeans-colors` changelog
 
+## Version 0.6.0 - 2023-07
+
+Version bump for updating `palette` to `0.7`.
+
+Users will need to change calls using
+`palette::Pixel::{from_raw_slice, into_raw_slice}`
+to `palette::cast::{from_component_slice, into_component_slice}` for preparing
+the input image buffer. See the [documentation] or `lib.rs` file for examples.
+
+[#52][52] - Upgrade palette to 0.7, bump crate version to 0.6, update CI/CD workflow
+
 ## Version 0.5.0 - 2022-03-17
 
 Version bump for updating `palette` to `0.6`.
@@ -84,6 +95,7 @@ performance to color and format conversions.
 ## Version 0.1.0 - 2020-04
 * Initial Commit
 
+[52]: https://github.com/okaneco/kmeans-colors/pull/52
 [49]: https://github.com/okaneco/kmeans-colors/pull/49
 [44]: https://github.com/okaneco/kmeans-colors/pull/44
 [41]: https://github.com/okaneco/kmeans-colors/pull/41
@@ -106,3 +118,4 @@ performance to color and format conversions.
 [6]: https://github.com/okaneco/kmeans-colors/pull/6
 [5]: https://github.com/okaneco/kmeans-colors/pull/5
 [3]: https://github.com/okaneco/kmeans-colors/pull/3
+[documentation]: https://docs.rs/kmeans_colors

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,12 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "adler32"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
-
-[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,9 +31,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bytemuck"
-version = "1.8.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e851ca7c24871e7336801608a4797d7376545b6928a10d32d75685687141ead"
+checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
 
 [[package]]
 name = "byteorder"
@@ -80,28 +74,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "deflate"
+name = "fast-srgb8"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86f7e25f518f4b81808a2cf1c50996a61f5c2eb394b2393bd87f2a4780a432f"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d329bdeac514ee06249dabc27877490f17f5d371ec693360768b838e19f3ae10"
 dependencies = [
- "adler32",
+ "simd-adler32",
 ]
 
 [[package]]
-name = "find-crate"
-version = "0.6.3"
+name = "flate2"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
- "toml",
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.5"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
@@ -119,15 +120,14 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.24.1"
+version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db207d030ae38f1eb6f240d5a1c1c88ff422aa005d10f8c6c6fc5e75286ab30e"
+checksum = "527909aa81e20ac3a44803521443a765550f09b5130c2c2fa1ea59c2f8f50a3a"
 dependencies = [
  "bytemuck",
  "byteorder",
  "color_quant",
  "jpeg-decoder",
- "num-iter",
  "num-rational",
  "num-traits",
  "png",
@@ -135,15 +135,16 @@ dependencies = [
 
 [[package]]
 name = "jpeg-decoder"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "105fb082d64e2100074587f59a74231f771750c664af903f1f9f76c9dedfc6f1"
+checksum = "bc0000e42512c92e31c2252315bda326620a4e034105e900c98ec492fa077b3e"
 
 [[package]]
 name = "kmeans_colors"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "image",
+ "num-traits",
  "palette",
  "rand",
  "rand_chacha",
@@ -158,45 +159,35 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.120"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad5c14e80759d0939d013e6ca49930e59fc53dd8e5009132f76240c179380c09"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
+ "simd-adler32",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
-dependencies = [
- "autocfg",
- "num-integer",
  "num-traits",
 ]
 
 [[package]]
 name = "num-rational"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -205,53 +196,53 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "palette"
-version = "0.6.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9735f7e1e51a3f740bacd5dc2724b61a7806f23597a8736e679f38ee3435d18"
+checksum = "e1641aee47803391405d0a1250e837d2336fdddd18b27f3ddb8c1d80ce8d7f43"
 dependencies = [
  "approx",
- "num-traits",
+ "fast-srgb8",
  "palette_derive",
 ]
 
 [[package]]
 name = "palette_derive"
-version = "0.6.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7799c3053ea8a6d8a1193c7ba42f534e7863cf52e378a7f90406f4a645d33bad"
+checksum = "3c02bfa6b3ba8af5434fa0531bf5701f750d983d4260acd6867faca51cdc4484"
 dependencies = [
- "find-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.27",
 ]
 
 [[package]]
 name = "png"
-version = "0.17.5"
+version = "0.17.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc38c0ad57efb786dd57b9864e5b18bae478c00c824dc55a38bbc9da95dde3ba"
+checksum = "59871cc5b6cce7eaccca5a802b4173377a1c2ba90654246789a8fa2334426d11"
 dependencies = [
  "bitflags",
  "crc32fast",
- "deflate",
+ "fdeflate",
+ "flate2",
  "miniz_oxide",
 ]
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro-error"
@@ -262,7 +253,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -279,18 +270,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.15"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
+checksum = "5fe8a65d69dd0808184ebb5f836ab526bb259db23c657efa38711b1072ee47f0"
 dependencies = [
  "proc-macro2",
 ]
@@ -318,18 +309,18 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.136"
+name = "simd-adler32"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+checksum = "238abfbb77c1915110ad968465608b68e869e0772622c9656714e73e5a1a522f"
 
 [[package]]
 name = "structopt"
@@ -352,18 +343,29 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.89"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea297be220d52398dcc07ce15a209fce436d361735ac1db700cab3b6cdfb9f54"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -376,31 +378,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.5.8"
+name = "unicode-ident"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
-dependencies = [
- "serde",
-]
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "version_check"
@@ -410,6 +403,6 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kmeans_colors"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["okaneco <47607823+okaneco@users.noreply.github.com>"]
 edition = "2018"
 exclude = ["test", "gfx", ".github"]
@@ -25,16 +25,22 @@ app = [
     ]
 
 # Enable `palette` color types
-palette_color = ["palette"]
+palette_color = ["palette", "num-traits"]
 
 [dependencies.image]
-version = "0.24.1"
+version = "0.24.6"
 default-features = false
 features = ["jpeg", "png"]
 optional = true
 
 [dependencies.palette]
-version = "0.6.0"
+version = "0.7.2"
+default-features = false
+features = ["std"]
+optional = true
+
+[dependencies.num-traits]
+version = "0.2.16"
 default-features = false
 features = ["std"]
 optional = true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # kmeans-colors
-[![Build Status](https://img.shields.io/github/workflow/status/okaneco/kmeans-colors/Rust%20CI)](https://github.com/okaneco/kmeans-colors)
+[![Build Status](https://github.com/okaneco/kmeans-colors/workflows/Rust%20CI/badge.svg)](https://github.com/okaneco/kmeans-colors)
 [![Crates.io](https://img.shields.io/crates/v/kmeans-colors.svg)](https://crates.io/crates/kmeans-colors)
 [![Docs.rs](https://docs.rs/kmeans_colors/badge.svg)](https://docs.rs/kmeans_colors)
 
@@ -21,7 +21,7 @@ be found at https://github.com/okaneco/kmeans-colors/releases.
 
 ```toml
 [dependencies.kmeans_colors]
-version = "0.5"
+version = "0.6"
 default-features = false
 ```
 

--- a/src/bin/kmeans_colors/main.rs
+++ b/src/bin/kmeans_colors/main.rs
@@ -24,33 +24,7 @@ fn main() {
 fn try_main() -> Result<(), Box<dyn Error>> {
     let opt = Opt::from_args();
     match opt.cmd {
-        Some(Command::Find {
-            input,
-            colors,
-            replace,
-            max_iter,
-            factor,
-            runs,
-            percentage,
-            rgb,
-            verbose,
-            output,
-            seed,
-            transparent,
-        }) => find_colors(
-            input,
-            colors,
-            replace,
-            max_iter,
-            factor,
-            runs,
-            percentage,
-            rgb,
-            verbose,
-            output,
-            seed,
-            transparent,
-        )?,
+        Some(command @ Command::Find { .. }) => find_colors(command)?,
         _ => run(opt)?,
     }
 

--- a/src/bin/kmeans_colors/utils.rs
+++ b/src/bin/kmeans_colors/utils.rs
@@ -5,7 +5,7 @@ use std::io::BufWriter;
 use std::path::Path;
 
 use image::ImageEncoder;
-use palette::{IntoColor, Pixel, Srgb};
+use palette::{IntoColor, Srgb};
 
 use crate::err::CliError;
 use kmeans_colors::{Calculate, CentroidData};
@@ -191,14 +191,14 @@ pub fn save_palette<C: Calculate + Copy + IntoColor<Srgb>>(
                 .centroid
                 .into_color()
                 .into_format()
-                .into_raw();
+                .into();
             *pixel = image::Rgb(color);
         }
     } else {
         let mut curr_pos = 0;
         if let Some((last, elements)) = res.split_last() {
             for r in elements.iter() {
-                let pix: [u8; 3] = r.centroid.into_color().into_format().into_raw();
+                let pix: [u8; 3] = r.centroid.into_color().into_format().into();
                 // Clamp boundary to image width
                 let boundary =
                     ((curr_pos as f32 + (r.percentage * w as f32)).round() as u32).min(w);
@@ -213,7 +213,7 @@ pub fn save_palette<C: Calculate + Copy + IntoColor<Srgb>>(
                 }
                 curr_pos = boundary;
             }
-            let pix: [u8; 3] = last.centroid.into_color().into_format().into_raw();
+            let pix: [u8; 3] = last.centroid.into_color().into_format().into();
             for y in 0..height {
                 for x in curr_pos..w {
                     imgbuf.put_pixel(x, y, image::Rgb(pix));

--- a/src/kmeans.rs
+++ b/src/kmeans.rs
@@ -204,7 +204,7 @@ impl Default for HamerlyPoint {
 /// the naive method at low center counts like `k=1`. Benchmark the functions to
 /// see which performs better for your use case.
 ///
-/// Example implementations for `Lab` and `Srgb` can be found in
+/// Example implementations for `Lab` and `Rgb` can be found in
 /// [`colors/kmeans.rs`][hamerly].
 ///
 /// [hamerly]: ../src/kmeans_colors/colors/kmeans.rs.html#165

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! When using the library, set `default-features = false` in the Cargo.toml to
 //! avoid bringing in the binary dependencies. If working with colors,
 //! implementations have been provided for the [`palette`][palette] `Lab` and
-//! `Srgb` color types behind the `palette_color` feature.
+//! `Rgb` color types behind the `palette_color` feature.
 //!
 //! The binary located in `src/bin/kmeans_colors` shows examples of crate
 //! usage.
@@ -24,7 +24,7 @@
 //! the [`Calculate`](trait.Calculate.html) trait. Further,
 //! [`Hamerly`](trait.Hamerly.html) can be implemented to enable use of the
 //! Hamerly optimization and [`get_kmeans_hamerly`][hamerly]. See the `Lab` and
-//! `Srgb` implementations in [`colors/kmeans.rs`][kmeans] for examples. These
+//! `Rgb` implementations in [`colors/kmeans.rs`][kmeans] for examples. These
 //! implementations can be used as groundwork for implementing with other types
 //! and should not require much modification beyond the distance calculations.
 //!
@@ -34,11 +34,11 @@
 //! ## Calculating k-means with `palette_color`
 //!
 //! The `palette_color` feature provides implementations of the `Calculate`
-//! trait for the `Lab` color space and `Srgb` color space. Each space has
+//! trait for the `Lab` color space and `Rgb` color space. Each space has
 //! advantages and drawbacks due to the characteristics of the color space.
 //!
 //! The `Lab` calculation produces more perceptually accurate results at a
-//! slightly slower runtime. `Srgb` calculation will converge faster than `Lab`
+//! slightly slower runtime. `Rgb` calculation will converge faster than `Lab`
 //! but the results may not visually correlate as well to the original image.
 //! Overall, properly converged results should not differ that drastically
 //! except at lower `k` counts. At `k=1`, the average color of an image,
@@ -55,7 +55,8 @@
 //! example converts an array of `u8` into `Lab` colors then finds the k-means.
 //!
 //! ```
-//! use palette::{FromColor, IntoColor, Lab, Pixel, Srgb};
+//! use palette::cast::{from_component_slice, into_component_slice};
+//! use palette::{FromColor, IntoColor, Lab, Srgb};
 //! use kmeans_colors::{get_kmeans, Calculate, Kmeans, MapColor, Sort};
 //!
 //! // An image buffer of one black pixel and one white pixel
@@ -68,7 +69,7 @@
 //! # let verbose = false;
 //! # let seed = 0;
 //! // Convert RGB [u8] buffer to Lab for k-means
-//! let lab: Vec<Lab> = Srgb::from_raw_slice(&img_vec)
+//! let lab: Vec<Lab> = from_component_slice::<Srgb<u8>>(&img_vec)
 //!     .iter()
 //!     .map(|x| x.into_format().into_color())
 //!     .collect();
@@ -95,7 +96,7 @@
 //!     .map(|x| Srgb::from_color(*x).into_format())
 //!     .collect::<Vec<Srgb<u8>>>();
 //! let buffer = Srgb::map_indices_to_centroids(&rgb, &result.indices);
-//! # assert_eq!(Srgb::into_raw_slice(&buffer), [119, 119, 119, 119, 119, 119]);
+//! # assert_eq!(into_component_slice(&buffer), [119, 119, 119, 119, 119, 119]);
 //! # // Test get_kmeans_hamerly
 //! # let mut result = Kmeans::new();
 //! # for i in 0..runs {
@@ -117,7 +118,7 @@
 //! #     .map(|x| Srgb::from_color(*x).into_format())
 //! #     .collect::<Vec<Srgb<u8>>>();
 //! # let buffer = Srgb::map_indices_to_centroids(&rgb, &result.indices);
-//! # assert_eq!(Srgb::into_raw_slice(&buffer), [119, 119, 119, 119, 119, 119]);
+//! # assert_eq!(into_component_slice(&buffer), [119, 119, 119, 119, 119, 119]);
 //! ```
 //!
 //! k-means++ is used for centroid initialization. Because the initialization is
@@ -127,7 +128,7 @@
 //! the convergence threshold has been met.
 //!
 //! The binary uses `8` as the default `k`. The iteration limit is set to `20`.
-//! The convergence factor defaults to `5.0` for `Lab` and `0.0025` for `Srgb`.
+//! The convergence factor defaults to `5.0` for `Lab` and `0.0025` for `Rgb`.
 //! The number of runs defaults to `3` for one of the binary subcommands.
 //! If the results do not appear correct, raise the iteration limit as
 //! convergence was probably not met.
@@ -141,7 +142,7 @@
 //!
 //! [sort]: trait.Sort.html#tymethod.sort_indexed_colors
 //! ```
-//! # use palette::{FromColor, IntoColor, Lab, Pixel, Srgb};
+//! # use palette::{cast::from_component_slice, FromColor, IntoColor, Lab, Srgb};
 //! # use kmeans_colors::{get_kmeans, Kmeans};
 //! use kmeans_colors::Sort;
 //!
@@ -152,7 +153,7 @@
 //! # let converge = 8.0;
 //! # let verbose = false;
 //! # let seed = 0;
-//! # let lab: Vec<Lab> = Srgb::from_raw_slice(&img_vec)
+//! # let lab: Vec<Lab> = from_component_slice::<Srgb<u8>>(&img_vec)
 //! #    .iter()
 //! #    .map(|x| x.into_format().into_color())
 //! #    .collect();
@@ -182,7 +183,7 @@
 //!
 //! // Or we can manually sort the vec by percentage, and the most appearing
 //! // color will be the first element
-//! res.sort_unstable_by(|a, b| (b.percentage).partial_cmp(&a.percentage).unwrap());
+//! res.sort_unstable_by(|a, b| (b.percentage).total_cmp(&a.percentage));
 //! let dominant_color = res.first().unwrap().centroid;
 //! ```
 #![warn(missing_docs, rust_2018_idioms, unsafe_code)]


### PR DESCRIPTION
Upgrade to `palette 0.7.2` and `image 0.24.6` versions
Fix CI badge in `README.md`
Fix lib tests for new `palette` version
Implement traits for `Rgb` instead of `Srgb`
Replace `Pixel` with corresponding `cast::[into|from]component_slice`
Replace `into_raw` with `into`
Add `num-traits` crate, use `Float` for generics
Remove unnecessary `Whitepoint` bounds
Default to `Lab<D65, f32>` in `app.rs`
Use enum to reduce arguments in `app::find_colors`

cc #51 