### PR TITLE
Speed up `Lab` conversion with `Srgb`/`LinSrgb` fast path, use `palette` `FromStr` impl

### DIFF
--- a/src/bin/kmeans_colors/app.rs
+++ b/src/bin/kmeans_colors/app.rs
@@ -30,13 +30,13 @@ pub fn run(opt: Opt) -> Result<(), Box<dyn Error>> {
             let lab: Vec<Lab<D65, f32>> = if !opt.transparent {
                 from_component_slice::<Srgba<u8>>(img_vec)
                     .iter()
-                    .map(|x| x.into_format::<_, f32>().into_color())
+                    .map(|x| x.into_linear::<_, f32>().into_color())
                     .collect()
             } else {
                 from_component_slice::<Srgba<u8>>(img_vec)
                     .iter()
                     .filter(|x| x.alpha == 255)
-                    .map(|x| x.into_format::<_, f32>().into_color())
+                    .map(|x| x.into_linear::<_, f32>().into_color())
                     .collect()
             };
 
@@ -112,7 +112,7 @@ pub fn run(opt: Opt) -> Result<(), Box<dyn Error>> {
                 let centroids = &result
                     .centroids
                     .iter()
-                    .map(|x| Srgb::from_color(*x).into_format())
+                    .map(|&x| Srgb::from_linear(x.into_color()))
                     .collect::<Vec<Srgb<u8>>>();
                 let lab: Vec<Srgb<u8>> = Srgb::map_indices_to_centroids(centroids, &result.indices);
 
@@ -130,7 +130,7 @@ pub fn run(opt: Opt) -> Result<(), Box<dyn Error>> {
                 let mut indices = Vec::with_capacity(img_vec.len());
                 let lab: Vec<Lab<D65, f32>> = from_component_slice::<Srgba<u8>>(img_vec)
                     .iter()
-                    .map(|x| x.into_format::<_, f32>().into_color())
+                    .map(|x| x.into_linear::<_, f32>().into_color())
                     .collect();
                 Lab::<D65, f32>::get_closest_centroid(&lab, &result.centroids, &mut indices);
 
@@ -329,7 +329,7 @@ pub fn find_colors(
         for c in colors {
             centroids.push(
                 (parse_color(c.trim_start_matches('#'))?)
-                    .into_format()
+                    .into_linear::<f32>()
                     .into_color(),
             );
         }
@@ -346,13 +346,13 @@ pub fn find_colors(
             let lab: Vec<Lab<D65, f32>> = if !transparent {
                 from_component_slice::<Srgba<u8>>(img_vec)
                     .iter()
-                    .map(|x| x.into_format::<_, f32>().into_color())
+                    .map(|x| x.into_linear::<_, f32>().into_color())
                     .collect()
             } else {
                 from_component_slice::<Srgba<u8>>(img_vec)
                     .iter()
                     .filter(|x| x.alpha == 255)
-                    .map(|x| x.into_format::<_, f32>().into_color())
+                    .map(|x| x.into_linear::<_, f32>().into_color())
                     .collect()
             };
 
@@ -371,7 +371,7 @@ pub fn find_colors(
                 if !transparent {
                     let rgb_centroids = &centroids
                         .iter()
-                        .map(|x| Srgb::from_color(*x).into_format())
+                        .map(|&x| Srgb::from_linear(x.into_color()))
                         .collect::<Vec<Srgb<u8>>>();
                     let lab: Vec<Srgb<u8>> =
                         Srgb::map_indices_to_centroids(rgb_centroids, &indices);
@@ -386,7 +386,7 @@ pub fn find_colors(
                 } else {
                     let rgb_centroids = &centroids
                         .iter()
-                        .map(|x| Srgb::from_color(*x).into_format())
+                        .map(|&x| Srgb::from_linear(x.into_color()))
                         .collect::<Vec<Srgb>>();
 
                     let mut indices = Vec::with_capacity(img_vec.len());

--- a/src/bin/kmeans_colors/err.rs
+++ b/src/bin/kmeans_colors/err.rs
@@ -26,13 +26,11 @@ impl From<std::time::SystemTimeError> for CliError {
 
 impl std::fmt::Display for CliError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match *self {
-            CliError::File(ref err) => write!(f, "File error: {}", err),
-            CliError::InvalidHex => {
-                write!(f, "Error: Invalid hex color length, must be 6 characters.")
-            }
-            CliError::Parse(ref err) => write!(f, "Parse error: {}", err),
-            CliError::Time(ref err) => write!(f, "Time error: {}", err),
+        match self {
+            CliError::File(err) => write!(f, "{err}"),
+            CliError::Parse(err) => write!(f, "{err}"),
+            CliError::Time(err) => write!(f, "{err}"),
+            CliError::InvalidHex => write!(f, "Invalid hex color, must be 3 or 6 digts"),
         }
     }
 }
@@ -41,9 +39,9 @@ impl std::error::Error for CliError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             CliError::File(err) => Some(err),
-            CliError::InvalidHex => None,
             CliError::Parse(err) => Some(err),
             CliError::Time(err) => Some(err),
+            CliError::InvalidHex => None,
         }
     }
 }

--- a/src/bin/kmeans_colors/main.rs
+++ b/src/bin/kmeans_colors/main.rs
@@ -16,7 +16,7 @@ use args::{Command, Opt};
 
 fn main() {
     if let Err(e) = try_main() {
-        eprintln!("{}", e);
+        eprintln!("kmeans_colors: {e}");
         process::exit(1);
     }
 }

--- a/src/bin/kmeans_colors/utils.rs
+++ b/src/bin/kmeans_colors/utils.rs
@@ -3,6 +3,7 @@ use std::fmt::Write;
 use std::fs::File;
 use std::io::BufWriter;
 use std::path::Path;
+use std::str::FromStr;
 
 use image::ImageEncoder;
 use palette::{IntoColor, Srgb};
@@ -12,37 +13,10 @@ use kmeans_colors::{Calculate, CentroidData};
 
 /// Parse hex string to Rgb color.
 pub fn parse_color(c: &str) -> Result<Srgb<u8>, CliError> {
-    let red = u8::from_str_radix(
-        match &c.get(0..2) {
-            Some(x) => x,
-            None => {
-                eprintln!("Invalid color: {}", c);
-                return Err(CliError::InvalidHex);
-            }
-        },
-        16,
-    )?;
-    let green = u8::from_str_radix(
-        match &c.get(2..4) {
-            Some(x) => x,
-            None => {
-                eprintln!("Invalid color: {}", c);
-                return Err(CliError::InvalidHex);
-            }
-        },
-        16,
-    )?;
-    let blue = u8::from_str_radix(
-        match &c.get(4..6) {
-            Some(x) => x,
-            None => {
-                eprintln!("Invalid color: {}", c);
-                return Err(CliError::InvalidHex);
-            }
-        },
-        16,
-    )?;
-    Ok(Srgb::new(red, green, blue))
+    Srgb::from_str(c).or_else(|_| {
+        eprintln!("Invalid color: {c}");
+        Err(CliError::InvalidHex)
+    })
 }
 
 /// Prints colors and percentage of their appearance in an image buffer.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@
 //! // Convert RGB [u8] buffer to Lab for k-means
 //! let lab: Vec<Lab> = from_component_slice::<Srgb<u8>>(&img_vec)
 //!     .iter()
-//!     .map(|x| x.into_format().into_color())
+//!     .map(|x| x.into_linear().into_color())
 //!     .collect();
 //!
 //! // Iterate over the runs, keep the best results
@@ -93,7 +93,7 @@
 //! // Convert indexed colors back to Srgb<u8> for output
 //! let rgb = &result.centroids
 //!     .iter()
-//!     .map(|x| Srgb::from_color(*x).into_format())
+//!     .map(|&x| Srgb::from_linear(x.into_color()))
 //!     .collect::<Vec<Srgb<u8>>>();
 //! let buffer = Srgb::map_indices_to_centroids(&rgb, &result.indices);
 //! # assert_eq!(into_component_slice(&buffer), [119, 119, 119, 119, 119, 119]);
@@ -115,7 +115,7 @@
 //! # // Convert indexed colors back to Srgb<u8> for output
 //! # let rgb = &result.centroids
 //! #     .iter()
-//! #     .map(|x| Srgb::from_color(*x).into_format())
+//! #     .map(|&x| Srgb::from_linear(x.into_color()))
 //! #     .collect::<Vec<Srgb<u8>>>();
 //! # let buffer = Srgb::map_indices_to_centroids(&rgb, &result.indices);
 //! # assert_eq!(into_component_slice(&buffer), [119, 119, 119, 119, 119, 119]);


### PR DESCRIPTION
 - Swap to using palette's `FromStr` implementation for colors. Now 3 or 6 digit hex colors are permitted.
- Use the special-cased `Srgb`/`LinSrgb` conversion between `u8` and `f32`/`f64` where possible, that version uses a lookup table and approximation

Speedup gains increase as image size increases. On a 4500x3000 image, a 44% speedup was seen reducing the total time to calculate centroids from 7.8s to 4.3s after switching from `into_format` to using `into_linear`. The speedup is closer to 15-17% on smaller images (320x200) but still noticeable when measured.

Example speedups for reading in images in `Rgb`, converting them to `Lab`, and calculating the centroids. Prompted from this discussion https://github.com/Ogeon/palette/discussions/341#discussioncomment-6561118
|Image Size|`into_format`|`into_linear`|
|:-:|-:|-:|
|4547x3032|7.8s|**4.3s**|
|1700x2200|2.4s|**1.3s**|
|805x1000|0.48s|**0.35s**|
|320x206|0.056s|**0.046s**|

